### PR TITLE
fix off-by-one in formatSC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ include $(BOLOS_SDK)/Makefile.defines
 
 APPNAME    = Sia
 ICONNAME   = nanos_app_sia.gif
-APPVERSION = 0.4.1
+APPVERSION = 0.4.2
 
 # The --path argument here restricts which BIP32 paths the app is allowed to derive.
 APP_LOAD_PARAMS = --appFlags 0x40 --path "44'/93'" --curve secp256k1 --curve ed25519 $(COMMON_LOAD_PARAMS)

--- a/src/sia.c
+++ b/src/sia.c
@@ -136,7 +136,7 @@ int formatSC(uint8_t *buf, uint8_t decLen) {
 		os_memset(buf, '0', SC_ZEROS+2-decLen);
 		decLen = SC_ZEROS + 1;
 	} else {
-		os_memmove(buf + (decLen-SC_ZEROS)+2, buf + (decLen-SC_ZEROS+1), SC_ZEROS+1);
+		os_memmove(buf + (decLen-SC_ZEROS)+1, buf + (decLen-SC_ZEROS), SC_ZEROS+1);
 	}
 	// add decimal point, trim trailing zeros, and add units
 	buf[decLen-SC_ZEROS] = '.';


### PR DESCRIPTION
This was causing SC amounts to be displayed incorrectly.

The `os_memmove` call in this function copies the buffer into itself, shifted by 1, e.g.:
```
old: 12345
new: 123345
```
The duplicated element (3 in this example) is later overwritten with a `.`. Effectively, we are making room for a decimal point. But due to an off-by-one, the duplication occurs in the wrong position, producing `123445`. Consequently, the value is displayed as `12.445` instead of the intended `12.345`.