### PR TITLE
Update replay protection prefix for Foundation hardfork

### DIFF
--- a/src/calcTxnHash.c
+++ b/src/calcTxnHash.c
@@ -288,10 +288,7 @@ void handleCalcTxnHash(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 		dataBuffer += 4; dataLength -= 4;
 		uint16_t sigIndex = U2LE(dataBuffer, 0);
 		dataBuffer += 2; dataLength -= 2;
-		// The official Sia Nano S app only signs transactions on the forked
-		// chain. To use the app on dissenting chains, pass false instead.
-		const bool useASICHardforkChain = true;
-		txn_init(&ctx->txn, sigIndex, useASICHardforkChain);
+		txn_init(&ctx->txn, sigIndex);
 
 		// Set ctx->sign according to P2.
 		ctx->sign = (p2 & P2_SIGN_HASH);

--- a/src/sia.h
+++ b/src/sia.h
@@ -46,7 +46,6 @@ typedef struct {
 	uint16_t sliceIndex;    // offset within current element slice
 
 	uint16_t sigIndex;   // index of TxnSig being computed
-	bool asicChain;      // apply ASIC hardfork replay protection
 	cx_blake2b_t blake;  // hash state
 	uint8_t sigHash[32]; // buffer to hold final hash
 
@@ -57,7 +56,7 @@ typedef struct {
 
 // txn_init initializes a transaction decoder, preparing it to calculate the
 // requested SigHash.
-void txn_init(txn_state_t *txn, uint16_t sigIndex, bool asicChain);
+void txn_init(txn_state_t *txn, uint16_t sigIndex);
 
 // txn_update adds data to a transaction decoder.
 void txn_update(txn_state_t *txn, uint8_t *in, uint8_t inlen);


### PR DESCRIPTION
**--DO NOT MERGE UNTIL HARDFORK ACTIVATION ON FEB 3 2021--**

This PR changes the replay protection prefix from 0 to 1, in accordance with the [Sia Foundation hardfork](https://gitlab.com/NebulousLabs/Sia/-/merge_requests/4822), scheduled to activate at height 298,000. After the hardfork, users will need to update to the latest version of the app for their signatures to be valid on the fork chain.

The minimal version of this change is simply to change a `0` to a `1`, but I opted to refactor the replay protection code a little as well.